### PR TITLE
Subdirectory support

### DIFF
--- a/package/photoframe/photoframe.sh
+++ b/package/photoframe/photoframe.sh
@@ -149,7 +149,8 @@ function start {
 
     # abuse error reporting to show the path of the current picture
     error_settopic 02_Current
-    error_write "$IMAGE"
+	#don't show the FOLDER_IMAGES prefix
+    error_write "$( echo "$IMAGE" | sed -e "s|^${FOLDER_IMAGES}/||" )"
 
     error_display
     sleep $SLIDESHOW_DELAY


### PR DESCRIPTION
These are quite a few topics, but I have a pull request ready (works on my setup).

I have web dav server that contains several subdirectories (basically one per vacation).
These directories have names with spaces (e.g., "2016-06 Hawaii" or "2018-02 Italy") and can again have subdirectories.
They contain some videos in addition to the pictures.

I did some changes to photoframe.sh such that
1. spaces are handled
2. rsync does not copy the videos
3. only jpg, JPG, and png are counted in the get_file function

I also abused the error reporting mechanism to show the name of the current file (I would like to know whether I'm looking at Hawaii or Italy).